### PR TITLE
chore: update urls for custom domain setup

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -36,7 +36,7 @@ Feel free to [open issues][open-issues], [submit pull requests][submit-pr], or [
 For more information, please refer to the [LICENSE](../LICENSE) file.
 
 [docsify]: https://docsify.js.org/
-[pillarbox-docs]: https://srgssr.github.io/pillarbox-documentation
+[pillarbox-docs]: https://www.pillarbox.ch
 [open-issues]: https://github.com/srgssr/pillarbox-documentation/issues/new
 [submit-pr]: https://github.com/srgssr/pillarbox-documentation/compare
 [discussions]: https://github.com/srgssr/pillarbox-documentation/discussions

--- a/public/README.md
+++ b/public/README.md
@@ -14,17 +14,17 @@ and best practices.
 
 ## Platform Repositories and Resources
 
-| Platform   | Repository Link                                                  | Demo Link                                                                           | Documentation Link                                                                                 |
-|------------|------------------------------------------------------------------|-------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------|
-| 🤖 Android | [pillarbox-android](https://github.com/SRGSSR/pillarbox-android) | [Demo Android](https://github.com/SRGSSR/pillarbox-android?tab=readme-ov-file#demo) | [Docs Android](https://github.com/SRGSSR/pillarbox-android?tab=readme-ov-file#integrate-pillarbox) |
-| 🍎 Apple   | [pillarbox-apple](https://github.com/SRGSSR/pillarbox-apple)     | [Demo Apple](https://testflight.apple.com/join/TS6ngLqf)                            | [Docs Apple](https://swiftpackageindex.com/SRGSSR/pillarbox-apple/3.0.0/documentation/pillarboxplayer)                                 |
-| 🌐 Web     | [pillarbox-web](https://github.com/SRGSSR/pillarbox-web)         | [Demo Web](https://srgssr.github.io/pillarbox-web-demo/)                            | [Docs Web](https://srgssr.github.io/pillarbox-web/api/)                                            |
+| Platform   | Repository Link                                                  | Demo Link                                                                           | Documentation Link                                                                                     |
+|------------|------------------------------------------------------------------|-------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|
+| 🤖 Android | [pillarbox-android](https://github.com/SRGSSR/pillarbox-android) | [Demo Android](https://github.com/SRGSSR/pillarbox-android?tab=readme-ov-file#demo) | [Docs Android](https://android.pillarbox.ch/api)                                                       |
+| 🍎 Apple   | [pillarbox-apple](https://github.com/SRGSSR/pillarbox-apple)     | [Demo Apple](https://testflight.apple.com/join/TS6ngLqf)                            | [Docs Apple](https://swiftpackageindex.com/SRGSSR/pillarbox-apple/3.0.0/documentation/pillarboxplayer) |
+| 🌐 Web     | [pillarbox-web](https://github.com/SRGSSR/pillarbox-web)         | [Demo Web](https://demo.pillarbox.ch)                                               | [Docs Web](https://web.pillarbox.ch/api/)                                                              |
 
 ## Web Tools for Pillarbox
 
 `pillarbox-web` provides a set of web tools for additional functionalities to enhance the developer's experience.
 
-| Repository Link                                                                    | Demo Link                                                    | Description                                      |
-|------------------------------------------------------------------------------------|--------------------------------------------------------------|--------------------------------------------------|
-| [pillarbox-web-suite](https://github.com/SRGSSR/pillarbox-web-suite)               | [Demo](https://srgssr.github.io/pillarbox-web-suite/)        | A collection of plugins, themes, and components. |
-| [pillarbox-web-theme-editor](https://github.com/SRGSSR/pillarbox-web-theme-editor) | [Demo](https://srgssr.github.io/pillarbox-web-theme-editor/) | A tool for editing themes for the player.        |
+| Repository Link                                                                    | Demo Link                            | Description                                      |
+|------------------------------------------------------------------------------------|--------------------------------------|--------------------------------------------------|
+| [pillarbox-web-suite](https://github.com/SRGSSR/pillarbox-web-suite)               | [Demo](https://plugins.pillarbox.ch) | A collection of plugins, themes, and components. |
+| [pillarbox-web-theme-editor](https://github.com/SRGSSR/pillarbox-web-theme-editor) | [Demo](https://editor.pillarbox.ch)  | A tool for editing themes for the player.        |


### PR DESCRIPTION
## Description

Use custom domain urls throughout the documentation.

## Changes Made

- Updated all URLs to the demo page to point to `demo.pillarbox.ch`
- Updated all API documentation URLs to point to `web.pillarbox.ch/api`
- Updated all URLs to the theme editor to point to `editor.pillarbox.ch`
- Updated all URLs to the web suite demo to point to `plugins.pillarbox.ch`
- Updated all URLs to the marketing page to point to `www.pillarbox.ch`
- Updated all URLs to the Android documentation page to point to `android.pillarbox.ch`
