### PR TITLE
Add log field to the status payload

### DIFF
--- a/public/specifications/monitoring/MONITORING.md
+++ b/public/specifications/monitoring/MONITORING.md
@@ -313,6 +313,7 @@ The associated event data dictionary supports the following keys:
 | `buffered_duration`  | Duration of the content currently available in buffer                                                | Time in milliseconds                                   | `12000`                                                                                     |
 | `duration`           | The content duration, as retrieved from the playlist                                                 | Time in milliseconds                                   | `16548`                                                                                     |
 | `frame_drops`        | The total number of frame drops experienced during the session                                       | Number                                                 | `12`                                                                                        |
+| `log`                | Any additional information that might be helpful                                                     | Any                                                    | `{ ... }`, `[...]`, `Stack trace symbols: ...`                                              |
 | `playback_duration`  | The duration of the playback session                                                                 | Time in milliseconds                                   | `40000`                                                                                     |
 | `position`           | The current player position, relative to the beginning of the playlist. Negative values are admitted | Time in milliseconds                                   | `16548`                                                                                     |
 | `position_timestamp` | The current player timestamp, as retrieved from the playlist. Omitted if not available               | [Unix timestamp](https://unixtime.org) in milliseconds | `1717665997932`                                                                             |
@@ -332,6 +333,7 @@ Some remarks:
 - The `playback_duration` **MUST** be measured in wall-clock time, independently of playback speed adjustments.
 - The `stream_type` is present in status events only, as those can more closely match potential stream type changes when
   a live playlist is closed and turns into an on-demand one.
+- The `log` is informally defined so that any useful information can be added for investigation purposes.
 
 ### JSON Schema
 

--- a/public/specifications/monitoring/schemas/status-schema.json
+++ b/public/specifications/monitoring/schemas/status-schema.json
@@ -32,18 +32,12 @@
           "description": "The content duration, as retrieved from the playlist, in milliseconds."
         },
         "log": {
-            "description": "Any additional information that might be helpful for debugging or investigation purposes. This can be any data type, including strings, objects, or arrays.",
-            "oneOf": [
-                {
-                    "type": "string"
-                },
-                {
-                    "type": "object"
-                },
-                {
-                    "type": "array"
-                }
-            ]
+          "description": "Any additional information that might be helpful for debugging or investigation purposes. This can be any data type, including strings, objects, or arrays.",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "object" },
+            { "type": "array" }
+          ]
         },
         "playback_duration": {
           "type": "number",

--- a/public/specifications/monitoring/schemas/status-schema.json
+++ b/public/specifications/monitoring/schemas/status-schema.json
@@ -31,6 +31,20 @@
           "type": "number",
           "description": "The content duration, as retrieved from the playlist, in milliseconds."
         },
+        "log": {
+            "description": "Any additional information that might be helpful for debugging or investigation purposes. This can be any data type, including strings, objects, or arrays.",
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "object"
+                },
+                {
+                    "type": "array"
+                }
+            ]
+        },
         "playback_duration": {
           "type": "number",
           "description": "The duration of the playback session in milliseconds, measured in wall-clock time."


### PR DESCRIPTION
## Description

This PR extends `log` support to status events.

## Changes Made

Self-explanatory.
