### PR TITLE
Add a link to Grafana in the monitoring specification

### DIFF
--- a/public/specifications/monitoring/MONITORING.md
+++ b/public/specifications/monitoring/MONITORING.md
@@ -9,7 +9,7 @@
 
 ## Introduction
 
-Pillarbox integrates with a monitoring platform that provides real-time and historical dashboards for:
+Pillarbox integrates with a [monitoring platform](https://grafana.pillarbox.ch) that provides real-time and historical dashboards for:
 
 - Quality of Service (QoS): QoS refers to the performance level of a service, especially in terms of its transmission
   quality and service availability.


### PR DESCRIPTION
## Description

This PR adds a link to the Grafana in the monitoring specification.

## Changes Made

- A link has been added in `MONITORING.md`.