### PR TITLE
Point Apple documentation at latest tag

### DIFF
--- a/public/README.md
+++ b/public/README.md
@@ -17,7 +17,7 @@ and best practices.
 | Platform   | Repository Link                                                  | Demo Link                                                                           | Documentation Link                                                                                     |
 |------------|------------------------------------------------------------------|-------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|
 | 🤖 Android | [pillarbox-android](https://github.com/SRGSSR/pillarbox-android) | [Demo Android](https://github.com/SRGSSR/pillarbox-android?tab=readme-ov-file#demo) | [Docs Android](https://android.pillarbox.ch/api)                                                       |
-| 🍎 Apple   | [pillarbox-apple](https://github.com/SRGSSR/pillarbox-apple)     | [Demo Apple](https://testflight.apple.com/join/TS6ngLqf)                            | [Docs Apple](https://swiftpackageindex.com/SRGSSR/pillarbox-apple/3.0.0/documentation/pillarboxplayer) |
+| 🍎 Apple   | [pillarbox-apple](https://github.com/SRGSSR/pillarbox-apple)     | [Demo Apple](https://testflight.apple.com/join/TS6ngLqf)                            | [Docs Apple](https://swiftpackageindex.com/SRGSSR/pillarbox-apple/documentation/pillarboxplayer) |
 | 🌐 Web     | [pillarbox-web](https://github.com/SRGSSR/pillarbox-web)         | [Demo Web](https://demo.pillarbox.ch)                                               | [Docs Web](https://web.pillarbox.ch/api/)                                                              |
 
 ## Web Tools for Pillarbox


### PR DESCRIPTION
## Description

This PR updates the Pillarbox Apple documentation link so that it points at the latest tag built on SPI.

## Changes Made

Self-explanatory.