### PR TITLE
Add authentication token to enable preview deployments on external pull requests

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -23,3 +23,4 @@ jobs:
           source-dir: public
           preview-branch: gh-pages
           umbrella-dir: pr-preview
+          token: ${{ secrets.PREVIEW_TOKEN }}


### PR DESCRIPTION
## Description

This PR adds support for an authentication token to secure preview deployments triggered by external pull requests.

## Changes Made

- Added `PREVIEW_TOKEN` to the repository secrets.
- Updated the workflow file to use the `PREVIEW_TOKEN` for authenticated preview deployments.

