### PR TITLE
Remove authentication token

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -23,4 +23,3 @@ jobs:
           source-dir: public
           preview-branch: gh-pages
           umbrella-dir: pr-preview
-          token: ${{ secrets.PREVIEW_TOKEN }}


### PR DESCRIPTION
## Description

This PR removes the authentication token introduce with #166 because the preview didn't work for external PRs.

## Changes Made

- The Github workflow file has been updated.
- The `PREVIEW_TOKEN` has been removed from repository secrets.
